### PR TITLE
Fix SSH authentication fallback and connection testing improvements

### DIFF
--- a/tests/test_clickhouse_cli_fallback.py
+++ b/tests/test_clickhouse_cli_fallback.py
@@ -1,0 +1,75 @@
+import pytest
+
+
+@pytest.mark.anyio
+async def test_clickhouse_python_falls_back_to_cli(monkeypatch):
+    from tests.conftest import make_connection
+    from src.connectors.clickhouse.python import ClickHousePythonConnector
+    from types import SimpleNamespace
+
+    config = make_connection(
+        {
+            "connection_name": "ch_http",
+            "type": "clickhouse",
+            "servers": ["example.com:8123"],
+            "db": "default",
+            "username": "user",
+            "password": "pass",
+            "implementation": "python",
+            "ssh_tunnel": {
+                "host": "bastion.example.com",
+                "user": "alice",
+                "private_key": "/tmp/key",
+            },
+        }
+    )
+
+    connector = ClickHousePythonConnector(config)
+
+    class FakeSSHTunnel:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        async def start(self):
+            raise RuntimeError("SSH: Authentication failed - bad key")
+
+        async def stop(self):
+            pass
+
+    cli_start_called = False
+    cli_stop_called = False
+
+    class FakeCLITunnel:
+        def __init__(self, ssh_config, remote_host, remote_port):
+            self.remote_host = remote_host
+            self.remote_port = remote_port
+
+        async def start(self):
+            nonlocal cli_start_called
+            cli_start_called = True
+            return 60000
+
+        async def stop(self):
+            nonlocal cli_stop_called
+            cli_stop_called = True
+
+    class FakeClient:
+        def __init__(self, **kwargs):
+            self.kwargs = kwargs
+
+        def query(self, query, column_oriented=False):
+            return SimpleNamespace(column_names=["version()"], result_rows=[["24.1"]])
+
+        def close(self):
+            pass
+
+    monkeypatch.setattr("src.utils.ssh_tunnel.SSHTunnel", FakeSSHTunnel)
+    monkeypatch.setattr("src.connectors.clickhouse.python.CLISSHTunnel", FakeCLITunnel)
+    monkeypatch.setattr("src.connectors.clickhouse.python.clickhouse_connect.get_client", lambda **kw: FakeClient(**kw))
+
+    result = await connector.execute_query("SELECT version()")
+
+    assert "version()" in result
+    assert "24.1" in result
+    assert cli_start_called
+    assert cli_stop_called

--- a/tests/test_postgresql_cli_fallback.py
+++ b/tests/test_postgresql_cli_fallback.py
@@ -1,0 +1,78 @@
+import asyncio
+import types
+
+import pytest
+
+from src.connectors.postgresql.cli import PostgreSQLCLIConnector
+
+
+class DummyStdout:
+    def __init__(self, lines):
+        self._lines = [line.encode() for line in lines]
+
+    async def readline(self):
+        if self._lines:
+            return self._lines.pop(0)
+        return b""
+
+
+class DummyStderr:
+    def __init__(self, data=b""):
+        self._data = data
+        self._read = False
+
+    async def read(self):
+        if self._read:
+            return b""
+        self._read = True
+        return self._data
+
+
+class DummyProcess:
+    def __init__(self, lines, returncode=0, stderr=b""):
+        self.stdout = DummyStdout(lines)
+        self.stderr = DummyStderr(stderr)
+        self.returncode = returncode
+
+    def kill(self):
+        pass
+
+    async def wait(self):
+        return self.returncode
+
+
+@pytest.mark.anyio
+async def test_postgres_cli_retries_without_pgoptions(monkeypatch):
+    from tests.conftest import make_connection
+
+    config = make_connection(
+        {
+            "connection_name": "pg_cli_retry",
+            "type": "postgresql",
+            "servers": ["localhost:5432"],
+            "db": "postgres",
+            "username": "user",
+            "password": "pass",
+            "implementation": "cli",
+        }
+    )
+
+    connector = PostgreSQLCLIConnector(config)
+
+    call_log = []
+
+    async def fake_create_subprocess_exec(*cmd, stdout=None, stderr=None, env=None):
+        call_log.append(env.copy())
+        if len(call_log) == 1:
+            raise RuntimeError("psql: unsupported startup parameter in options: default_transaction_read_only")
+        return DummyProcess(["column", "value"], returncode=0)
+
+    monkeypatch.setattr(asyncio, "create_subprocess_exec", fake_create_subprocess_exec)
+
+    result = await connector.execute_query("SELECT version()")
+
+    assert "value" in result
+    assert len(call_log) == 2
+    assert call_log[0]["PGOPTIONS"].startswith("-c default_transaction_read_only")
+    assert "PGOPTIONS" not in call_log[1]
+


### PR DESCRIPTION
## Summary
- Add fallback to system SSH when Paramiko authentication fails in ClickHouse Python connector
- Add PGOPTIONS retry logic for PostgreSQL servers that don't support `default_transaction_read_only`
- Improve connection testing display for SSH tunneled connections
- Add ClickHouse HTTP fallback when native protocol is rejected

## Changes

### ClickHouse Python Connector
- Implement fallback from Paramiko-based SSH tunnel to system ssh when authentication fails
- Improves compatibility with SSH configurations that work with system ssh but not Paramiko

### PostgreSQL CLI Connector
- Add retry logic for servers that reject `PGOPTIONS` with `default_transaction_read_only`
- First attempt uses PGOPTIONS for read-only enforcement
- Falls back to connection without PGOPTIONS if server rejects the parameter
- Maintains read-only security through other enforcement layers

### Connection Testing Tool
- Improve server display for SSH tunneled connections (show actual remote host instead of localhost)
- Deduplicate server entries to avoid redundant connection attempts
- Add automatic fallback from ClickHouse native protocol to HTTP when protocol mismatch detected
- Simplify and unify query execution logic across database types

## Test Plan
- [x] Test SSH tunneled ClickHouse connections with Paramiko auth issues
- [x] Test PostgreSQL connections with servers that reject PGOPTIONS
- [x] Verify connection testing displays correct remote hosts for SSH tunnels
- [x] Test ClickHouse protocol fallback scenario