### PR TITLE
[codex] Expand ty coverage and refresh AGENTS guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,7 +1,7 @@
 # Repository Guidelines
 
 ## Project Structure & Module Organization
-`src/mcp_read_only_sql/server.py` exposes the MCP entry point, while `src/mcp_read_only_sql/connectors/` hosts the PostgreSQL and ClickHouse adapters. Cross-cutting helpers (`ssh_tunnel.py`, `sql_guard.py`, TSV formatting) live in `src/mcp_read_only_sql/utils/`. Configuration tooling, including DBeaver import and manifest validation, sits in `src/mcp_read_only_sql/config/` and `src/mcp_read_only_sql/tools/`. Tests are grouped in `tests/`, and Docker fixtures for integration runs reside in `docker/`. The package ships a sample `connections.yaml`, and runtime config lives under `~/.config/lukleh/mcp-read-only-sql/`.
+`src/mcp_read_only_sql/server.py` exposes the MCP entry point, while `src/mcp_read_only_sql/connectors/` hosts the PostgreSQL and ClickHouse adapters for both CLI and Python implementations. Cross-cutting helpers (`ssh_tunnel.py`, `ssh_tunnel_cli.py`, `sql_guard.py`, TSV formatting, timeout handling) live in `src/mcp_read_only_sql/utils/`. Configuration tooling, including DBeaver import and manifest validation, sits in `src/mcp_read_only_sql/config/` and `src/mcp_read_only_sql/tools/`. Tests are grouped in `tests/`, and Docker fixtures for integration runs reside in `docker/`. The package ships a sample `connections.yaml`, and runtime config lives under `~/.config/lukleh/mcp-read-only-sql/`.
 
 ## Build, Test, and Development Commands
 - `uv sync --extra dev` — install runtime and development dependencies.
@@ -11,9 +11,11 @@
 - `just validate` — lint `connections.yaml` against the schema and safety checks.
 - `just test` — spin up Dockerized fixtures and execute the full pytest suite via `./run_tests.sh`.
 - `uv run python -m pytest tests/test_sql_guard.py` — run an individual module when iterating quickly.
+- `uv run ruff check .` and `uv run black .` — run linting and formatting for the Python tree.
+- `uv run ty check` — type-check the full `src/` tree; there are no remaining package excludes.
 
 ## Coding Style & Naming Conventions
-Target Python 3.11+, four-space indentation, and Unix newlines. Format with `uv run black .` and lint via `uv run ruff check .`; CI mirrors these checks. Modules and callables use snake_case, classes PascalCase (e.g., `TestReadOnlyGuards`), and immutable settings uppercase (`DEFAULT_QUERY_TIMEOUT`). Apply type hints on public surfaces and keep docstrings brief, emphasising read-only guarantees.
+Target Python 3.11+, four-space indentation, and Unix newlines. Format with `uv run black .`, lint via `uv run ruff check .`, and keep `uv run ty check` passing for `src/`. Modules and callables use snake_case, classes PascalCase (e.g., `TestReadOnlyGuards`), and immutable settings uppercase (`DEFAULT_QUERY_TIMEOUT`). Apply type hints on public surfaces and keep docstrings brief, emphasizing read-only guarantees and connector behavior.
 
 ## Testing Guidelines
 Pytest discovers `test_*.py` modules, `Test*` classes, and `test_*` functions per `pytest.ini`. Use the built-in markers (`security`, `cli`, `python`, `ssh`, `slow`) to scope runs, e.g. `pytest -m "security and not slow"`. A 30s default timeout applies, so tear down tunnels and subprocesses explicitly. `just test` emits JUnit XML at `test-results/pytest.xml` for CI uploads.
@@ -22,4 +24,4 @@ Pytest discovers `test_*.py` modules, `Test*` classes, and `test_*` functions pe
 Recent commits favour imperative, concise subjects (“Refactor PostgreSQL read-only guard into shared utility”). Keep changes focused and explain security or connector impacts in the body when needed. Pull requests should describe motivation, list affected modules or scripts, link issues, and attach logs or screenshots for operational updates.
 
 ## Security & Configuration Tips
-Do not relax safeguards in `src/mcp_read_only_sql/utils/sql_guard.py` or connector factories without matching tests. Treat `connections.yaml` as sensitive; the server stores database and SSH passwords directly in that file, so keep it private and user-readable only. Use the SSH tunnel helpers instead of bespoke subprocesses to preserve timeout and read-only enforcement.
+Do not relax safeguards in `src/mcp_read_only_sql/utils/sql_guard.py` or connector factories without matching tests. Treat `connections.yaml` as sensitive; the server stores database and SSH passwords directly in that file, so keep it private and user-readable only. Use the shared SSH tunnel and timeout helpers instead of bespoke subprocesses so read-only enforcement, cleanup, and managed result-file behavior stay consistent.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,22 @@ and this project aims to follow [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+## [0.2.2] - 2026-04-03
+
+### Added
+
+- Added `ty` as a supported development check for the full packaged `src/` tree.
+
+### Changed
+
+- Added repo-specific `AGENTS.md` guidance covering connector layout, shared timeout and SSH helpers, and the typed development workflow.
+- Reworked `RELEASING.md` into an evergreen release checklist with explicit validation, tagging, and publish steps.
+
+### Fixed
+
+- Flushed the final buffered TSV line when PostgreSQL and ClickHouse CLI queries stream results to an output file.
+- Hardened DBeaver credential import so missing or non-dictionary decrypted sections are ignored cleanly instead of being treated as valid connection data.
+
 ## [0.2.1] - 2026-04-02
 
 ### Added

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,109 +1,76 @@
 # Releasing `mcp-read-only-sql`
 
-This repo follows the same package and release model as the other published MCP servers:
+This repository publishes to PyPI from Git tags through GitHub Actions.
 
-- package metadata in `pyproject.toml`
-- tag-driven GitHub Actions publish workflow
-- PyPI trusted publishing via the GitHub `pypi` environment
-- manual approval at the `pypi` environment before the final upload job
+Release automation lives in:
+- `.github/workflows/publish.yml`
+- `.github/workflows/test.yml`
+- the GitHub environment named `pypi`
+- the PyPI trusted publisher for `lukleh/mcp-read-only-sql`
 
-## CLI convention
+## What To Change For A Release
 
-- The public interface starts with the package command: `mcp-read-only-sql`.
-- Repository-facing docs should prefer the root command plus flags or subcommands, not extra top-level helper scripts.
-- This repo already uses subcommands for auxiliary operations:
-  - `mcp-read-only-sql import-dbeaver`
-  - `mcp-read-only-sql validate-config`
-  - `mcp-read-only-sql test-connection`
-  - `mcp-read-only-sql test-ssh-tunnel`
-- Future auxiliary operations should extend that subcommand surface instead of adding new public console entry points.
+Update these files in the release commit:
 
-## Current package status
+1. `CHANGELOG.md`
+   Move the user-visible items from `## [Unreleased]` into a new section:
+   `## [X.Y.Z] - YYYY-MM-DD`
+2. `pyproject.toml`
+   Update `[project].version` to `X.Y.Z`
 
-- PyPI package: published as `0.1.0`
-- Next planned release from current branch: `0.2.2`
-- Publish workflow: active on `main`
-- GitHub `pypi` environment: configured
-- Required reviewer: `lukleh`
-- Self-review: allowed
+Do not expect a tracked `uv.lock` change in this repository. `uv.lock` is
+gitignored here, so it is not part of the release diff.
 
-## Changelog policy
+`RELEASING.md` should stay evergreen. It should explain the process, not carry a
+release-specific version number.
 
-- Keep upcoming user-visible changes under `## [Unreleased]` in `CHANGELOG.md`.
-- On release, move those entries into a dated version section such as `## [0.2.2] - 2026-03-29`.
-- Prefer concise bullets grouped under `Added`, `Changed`, and `Fixed`.
-- When creating GitHub release notes, reuse the matching `CHANGELOG.md` section instead of writing a second summary from scratch.
+## How To Update The Version
 
-## One-time setup
+1. Edit `pyproject.toml`
+2. Refresh the local environment if needed:
 
-### PyPI
+```bash
+uv sync --extra dev
+```
 
-1. Log in to `https://pypi.org`.
-2. Add a trusted publisher for this repository.
-   If the project already exists, use the project's `Manage -> Publishing` page instead of the account-level `Publishing` page.
-   - Project name: `mcp-read-only-sql`
-   - Owner: `lukleh`
-   - Repository: `mcp-read-only-sql`
-   - Workflow filename: `publish.yml`
-   - Environment name: `pypi`
+3. Confirm the installed package metadata and CLI version output match:
 
-### GitHub
+```bash
+uv run --extra dev pytest tests/test_server.py tests/test_cli_versions.py -q -k 'package_version_matches_distribution_metadata or support_version'
+```
 
-1. Create an environment named `pypi`.
-2. Add at least one required reviewer.
-3. Decide whether self-review is allowed.
+## Pre-Release Validation
 
-Current repo configuration:
+Run the normal local checks before tagging:
 
-- Environment: `pypi`
-- Required reviewer: `lukleh`
-- Self-review: allowed
+```bash
+uv run --extra dev ruff check .
+uv run --extra dev ty check
+./run_tests.sh
+```
 
-## Release flow
+If you are iterating on release metadata only, the focused version tests above
+are the minimum sanity check.
 
-1. Update `CHANGELOG.md` for the release.
-2. Confirm `version` in `pyproject.toml` on `main`.
-3. Commit the release changes to `main`.
-4. Push a matching tag:
+## How To Publish
+
+1. Make the release commit on `main`
+2. Create and push the matching tag:
 
 ```bash
 git tag vX.Y.Z
+git push origin main
 git push origin vX.Y.Z
 ```
 
-5. GitHub Actions starts the `Publish` workflow automatically.
-6. The workflow runs the full release gate before approval:
-   - test matrix
-   - package build
-   - wheel smoke tests
-   - sdist smoke tests
-7. The final `publish` job pauses on the GitHub `pypi` environment.
-8. Approve the deployment.
-9. After approval, GitHub uploads the built package to PyPI.
+3. GitHub Actions starts `.github/workflows/publish.yml`
+4. The workflow runs the test matrix, builds the wheel and sdist, and smoke-tests the built artifacts
+5. The final publish job pauses on the GitHub `pypi` environment
+6. Approve the deployment in GitHub Actions
+7. GitHub publishes the package to PyPI
 
-## Prereleases
+## Notes
 
-Use normal PEP 440 prerelease versions in `pyproject.toml`, for example:
-
-- `0.2.0a1`
-- `0.2.0b1`
-- `0.2.0rc1`
-
-Push the matching tag:
-
-```bash
-git tag v0.2.0a1
-git push origin v0.2.0a1
-```
-
-The same workflow and approval gate handle prereleases.
-
-## SQL-specific notes
-
-- Keep both `implementation: cli` and `implementation: python` clearly supported in public docs.
-- `uvx` installs the MCP server package, not system database clients.
-- If users choose CLI mode, the docs should stay explicit about external requirements:
-  - PostgreSQL CLI mode needs `psql`
-  - ClickHouse CLI mode needs `clickhouse-client`
-  - CLI SSH password auth needs `sshpass`
-- Package smoke tests should cover the main server entry point and the management subcommands.
+- Keep both `implementation: cli` and `implementation: python` clearly supported in release notes and docs
+- `uvx` installs the Python package only; it does not install `psql`, `clickhouse-client`, or `sshpass`
+- If the public CLI or result-file behavior changes, keep the package smoke tests and README aligned with `mcp-read-only-sql`

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -21,7 +21,7 @@ This repo follows the same package and release model as the other published MCP 
 ## Current package status
 
 - PyPI package: published as `0.1.0`
-- Next planned release from current branch: `0.1.1`
+- Next planned release from current branch: `0.2.2`
 - Publish workflow: active on `main`
 - GitHub `pypi` environment: configured
 - Required reviewer: `lukleh`
@@ -30,7 +30,7 @@ This repo follows the same package and release model as the other published MCP 
 ## Changelog policy
 
 - Keep upcoming user-visible changes under `## [Unreleased]` in `CHANGELOG.md`.
-- On release, move those entries into a dated version section such as `## [0.1.1] - 2026-03-29`.
+- On release, move those entries into a dated version section such as `## [0.2.2] - 2026-03-29`.
 - Prefer concise bullets grouped under `Added`, `Changed`, and `Fixed`.
 - When creating GitHub release notes, reuse the matching `CHANGELOG.md` section instead of writing a second summary from scratch.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,6 +39,7 @@ dev = [
     "pytest-timeout>=2.2.0",
     "black>=23.0.0",
     "ruff>=0.1.0",
+    "ty>=0.0.28",
 ]
 
 [build-system]
@@ -50,3 +51,19 @@ mcp-read-only-sql = "mcp_read_only_sql.server:main"
 
 [tool.hatch.build.targets.wheel]
 packages = ["src/mcp_read_only_sql"]
+
+[tool.ty.src]
+include = ["src"]
+exclude = [
+    "src/mcp_read_only_sql/config/connection.py",
+    "src/mcp_read_only_sql/config/dbeaver_import.py",
+    "src/mcp_read_only_sql/config/loader.py",
+    "src/mcp_read_only_sql/connectors/clickhouse/cli.py",
+    "src/mcp_read_only_sql/connectors/clickhouse/python.py",
+    "src/mcp_read_only_sql/connectors/postgresql/cli.py",
+    "src/mcp_read_only_sql/connectors/postgresql/python.py",
+    "src/mcp_read_only_sql/tools/test_ssh_tunnel.py",
+    "src/mcp_read_only_sql/utils/json_serializer.py",
+    "src/mcp_read_only_sql/utils/ssh_tunnel.py",
+    "src/mcp_read_only_sql/utils/timeout_wrapper.py",
+]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "mcp-read-only-sql"
-version = "0.2.1"
+version = "0.2.2"
 description = "MCP server for read-only SQL queries supporting PostgreSQL and ClickHouse"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,16 +54,3 @@ packages = ["src/mcp_read_only_sql"]
 
 [tool.ty.src]
 include = ["src"]
-exclude = [
-    "src/mcp_read_only_sql/config/connection.py",
-    "src/mcp_read_only_sql/config/dbeaver_import.py",
-    "src/mcp_read_only_sql/config/loader.py",
-    "src/mcp_read_only_sql/connectors/clickhouse/cli.py",
-    "src/mcp_read_only_sql/connectors/clickhouse/python.py",
-    "src/mcp_read_only_sql/connectors/postgresql/cli.py",
-    "src/mcp_read_only_sql/connectors/postgresql/python.py",
-    "src/mcp_read_only_sql/tools/test_ssh_tunnel.py",
-    "src/mcp_read_only_sql/utils/json_serializer.py",
-    "src/mcp_read_only_sql/utils/ssh_tunnel.py",
-    "src/mcp_read_only_sql/utils/timeout_wrapper.py",
-]

--- a/src/mcp_read_only_sql/config/connection.py
+++ b/src/mcp_read_only_sql/config/connection.py
@@ -109,7 +109,7 @@ class SSHTunnelConfig:
                 raise ValueError("SSH tunnel timeout must be a positive integer")
 
     @classmethod
-    def from_dict(cls, data: Dict[str, Any]) -> "SSHTunnelConfig":
+    def from_dict(cls, data: Dict[str, Any]) -> Optional["SSHTunnelConfig"]:
         """Create SSHTunnelConfig from dict with validation."""
         if not data.get("enabled", True):
             return None

--- a/src/mcp_read_only_sql/config/dbeaver_import.py
+++ b/src/mcp_read_only_sql/config/dbeaver_import.py
@@ -31,10 +31,12 @@ class DBeaverImporter:
         self.last_requested_names: List[str] = []
         self.last_seen_names: List[str] = []
 
-    def _decrypt_credentials(self) -> Dict[str, Any]:
+    def _decrypt_credentials(
+        self,
+    ) -> tuple[dict[str, dict[str, Any]], dict[str, dict[str, Any]]]:
         """Decrypt DBeaver credentials file using OpenSSL with default AES key"""
         if not self.credentials_path.exists():
-            return {}
+            return {}, {}
 
         # DBeaver's default AES key and IV
         key = "babb4a9f774ab853c96c2d653dfe544a"
@@ -60,21 +62,23 @@ class DBeaverImporter:
                 logger.warning(
                     f"Could not decrypt credentials: {result.stderr.decode()}"
                 )
-                return {}
+                return {}, {}
 
             # Skip the first 16 bytes (padding) and parse JSON
             decrypted = result.stdout[16:]
             credentials_data = json.loads(decrypted)
 
             # Extract both connection and SSH credentials
-            credentials = {}
-            ssh_credentials = {}
+            credentials: dict[str, dict[str, Any]] = {}
+            ssh_credentials: dict[str, dict[str, Any]] = {}
             for conn_id, conn_data in credentials_data.items():
                 if isinstance(conn_data, dict):
-                    if "#connection" in conn_data:
-                        credentials[conn_id] = conn_data["#connection"]
-                    if "network/ssh_tunnel" in conn_data:
-                        ssh_credentials[conn_id] = conn_data["network/ssh_tunnel"]
+                    db_connection = conn_data.get("#connection")
+                    if isinstance(db_connection, dict):
+                        credentials[conn_id] = db_connection
+                    ssh_connection = conn_data.get("network/ssh_tunnel")
+                    if isinstance(ssh_connection, dict):
+                        ssh_credentials[conn_id] = ssh_connection
 
             logger.info(
                 f"Successfully decrypted credentials for {len(credentials)} connections"
@@ -83,7 +87,7 @@ class DBeaverImporter:
 
         except (subprocess.SubprocessError, json.JSONDecodeError) as e:
             logger.warning(f"Could not decrypt credentials file: {e}")
-            return {}
+            return {}, {}
 
     def import_connections(
         self, merge_clusters: bool = True, only_names: Optional[List[str]] = None
@@ -98,21 +102,20 @@ class DBeaverImporter:
             data_sources = json.load(handle)
 
         # Try to decrypt credentials
-        decrypt_result = self._decrypt_credentials()
-        if isinstance(decrypt_result, tuple):
-            credentials, ssh_credentials = decrypt_result
-        else:
-            credentials = decrypt_result or {}
-            ssh_credentials = {}
+        credentials, ssh_credentials = self._decrypt_credentials()
 
         if not credentials and self.credentials_path.exists():
             # Fallback: try to read as plaintext JSON (some DBeaver versions don't encrypt)
             try:
                 with self.credentials_path.open("r", encoding="utf-8") as handle:
                     cred_data = json.load(handle)
-                    for conn_id, conn_creds in cred_data.items():
-                        if isinstance(conn_creds, dict) and "#connection" in conn_creds:
-                            credentials[conn_id] = conn_creds["#connection"]
+                    if isinstance(cred_data, dict):
+                        for conn_id, conn_creds in cred_data.items():
+                            if not isinstance(conn_creds, dict):
+                                continue
+                            db_connection = conn_creds.get("#connection")
+                            if isinstance(db_connection, dict):
+                                credentials[conn_id] = db_connection
                     logger.info("Credentials file was not encrypted")
             except (json.JSONDecodeError, UnicodeDecodeError):
                 logger.warning(
@@ -125,10 +128,16 @@ class DBeaverImporter:
             print(f"Filtering: only {len(only_set)} requested connection(s)")
         self.last_requested_names = requested
 
-        connections = []
+        connections: list[dict[str, Any]] = []
         imported_names: List[str] = []
         seen_names: List[str] = []
-        for conn_id, conn_data in data_sources.get("connections", {}).items():
+        connections_data = data_sources.get("connections", {})
+        if not isinstance(connections_data, dict):
+            connections_data = {}
+
+        for conn_id, conn_data in connections_data.items():
+            if not isinstance(conn_data, dict):
+                continue
             original_name = conn_data.get("name", conn_id)
             if only_set and original_name not in only_set:
                 continue
@@ -136,9 +145,7 @@ class DBeaverImporter:
                 seen_names.append(original_name)
             # Pass both DB and SSH credentials
             db_creds = credentials.get(conn_id)
-            ssh_creds = (
-                ssh_credentials.get(conn_id) if "ssh_credentials" in locals() else None
-            )
+            ssh_creds = ssh_credentials.get(conn_id)
             converted = self._convert_connection(
                 conn_id, conn_data, db_creds, ssh_creds
             )
@@ -157,12 +164,14 @@ class DBeaverImporter:
         self,
         conn_id: str,
         conn_data: Dict[str, Any],
-        creds: Dict[str, Any] = None,
-        ssh_creds: Dict[str, Any] = None,
-    ) -> Dict[str, Any]:
+        creds: Optional[Dict[str, Any]] = None,
+        ssh_creds: Optional[Dict[str, Any]] = None,
+    ) -> Optional[Dict[str, Any]]:
         """Convert a DBeaver connection to our format"""
         provider = conn_data.get("provider", "")
         config = conn_data.get("configuration", {})
+        if not isinstance(config, dict):
+            config = {}
         conn_name = conn_data.get("name", conn_id)
 
         print(f"  Processing: {conn_name}...")
@@ -213,8 +222,14 @@ class DBeaverImporter:
 
         # Check for SSH tunnel configuration
         handlers = config.get("handlers", {})  # handlers is inside configuration
+        if not isinstance(handlers, dict):
+            handlers = {}
         ssh_handler = handlers.get("ssh_tunnel", {})
+        if not isinstance(ssh_handler, dict):
+            ssh_handler = {}
         ssh_props = ssh_handler.get("properties", {}) if ssh_handler else {}
+        if not isinstance(ssh_props, dict):
+            ssh_props = {}
 
         if ssh_handler and ssh_handler.get("enabled"):
             # Get SSH username from credentials or properties
@@ -368,9 +383,13 @@ class DBeaverImporter:
                         )
 
             # Add servers from this connection to the group
+            group_servers = group.get("servers")
+            if not isinstance(group_servers, list):
+                group_servers = []
+                group["servers"] = group_servers
             for server in servers:
-                if server not in group["servers"]:
-                    group["servers"].append(server)
+                if server not in group_servers:
+                    group_servers.append(server)
 
             # Track original DBeaver name
             if (
@@ -381,8 +400,12 @@ class DBeaverImporter:
                 import_part = (
                     conn["description"].split("(imported from DBeaver:")[-1].rstrip(")")
                 )
-                if import_part not in group["original_names"]:
-                    group["original_names"].append(import_part)
+                group_original_names = group.get("original_names")
+                if not isinstance(group_original_names, list):
+                    group_original_names = []
+                    group["original_names"] = group_original_names
+                if import_part not in group_original_names:
+                    group_original_names.append(import_part)
 
         # Return merged groups in original order with updated descriptions
         merged = []

--- a/src/mcp_read_only_sql/config/loader.py
+++ b/src/mcp_read_only_sql/config/loader.py
@@ -1,7 +1,7 @@
 """Connection configuration loader."""
 
 from pathlib import Path
-from typing import Dict
+from typing import Any, Dict, cast
 
 import yaml
 
@@ -35,16 +35,18 @@ def load_connections(yaml_path: str | Path) -> Dict[str, Connection]:
     if not isinstance(raw_configs, list):
         raise ValueError("Configuration file must contain a list of connections")
 
-    connections = {}
-    errors = []
+    connections: Dict[str, Connection] = {}
+    errors: list[str] = []
 
     for idx, config in enumerate(raw_configs):
         if not isinstance(config, dict):
             errors.append(f"Connection #{idx+1}: must be a dictionary")
             continue
 
+        config_dict = cast(Dict[str, Any], config)
+
         try:
-            conn = Connection(config)
+            conn = Connection(config_dict)
 
             # Check for duplicate names
             if conn.name in connections:
@@ -54,7 +56,7 @@ def load_connections(yaml_path: str | Path) -> Dict[str, Connection]:
 
         except Exception as e:
             # Get connection name if available for better error messages
-            name = config.get("connection_name", f"#{idx+1}")
+            name = config_dict.get("connection_name", f"#{idx+1}")
             errors.append(f"Connection '{name}': {e}")
 
     if errors:

--- a/src/mcp_read_only_sql/connectors/clickhouse/cli.py
+++ b/src/mcp_read_only_sql/connectors/clickhouse/cli.py
@@ -1,9 +1,9 @@
 import asyncio
 import logging
 import os
-from contextlib import asynccontextmanager, nullcontext, suppress
+from contextlib import asynccontextmanager, suppress
 from pathlib import Path
-from typing import Optional
+from typing import Callable, Optional
 
 from ..base_cli import BaseCLIConnector
 from ...utils.ssh_tunnel_cli import CLISSHTunnel
@@ -55,9 +55,10 @@ class ClickHouseCLIConnector(BaseCLIConnector):
         self, query: str, database: Optional[str] = None, server: Optional[str] = None
     ) -> str:
         """Execute a read-only query using clickhouse-client and return raw TSV output"""
-        return await self._run_query(
+        result = await self._run_query(
             query, database=database, server=server, output_path=None
         )
+        return result if result is not None else ""
 
     async def execute_query_to_file(
         self,
@@ -162,35 +163,38 @@ class ClickHouseCLIConnector(BaseCLIConnector):
                         if asyncio.iscoroutine(drain_result):
                             await drain_result
                     stdin.close()
+                elif self.password:
+                    process.kill()
+                    await process.wait()
+                    raise RuntimeError(
+                        "clickhouse-client: failed to create subprocess stdin pipe"
+                    )
 
                 stdout = process.stdout
-                stderr_task = asyncio.create_task(process.stderr.read())
+                stderr_stream = process.stderr
+                if stdout is None or stderr_stream is None:
+                    process.kill()
+                    await process.wait()
+                    raise RuntimeError(
+                        "clickhouse-client: failed to create subprocess pipes"
+                    )
 
-                lines = [] if output_path is None else None
-                pending_line = None
-                wrote_content = False
-
-                def emit_line(line: str) -> None:
-                    nonlocal wrote_content
-                    if output_path is None:
-                        lines.append(line)
-                    else:
-                        wrote_content = write_tsv_text_line(handle, line, wrote_content)
-
+                stderr_task = asyncio.create_task(stderr_stream.read())
+                lines: list[str] = []
                 loop = asyncio.get_event_loop()
                 deadline = loop.time() + self.query_timeout
 
-                async def read_line_with_timeout():
-                    remaining = deadline - loop.time()
-                    if remaining <= 0:
-                        raise asyncio.TimeoutError
-                    return await asyncio.wait_for(stdout.readline(), timeout=remaining)
+                async def stream_output(emit_line: Callable[[str], None]) -> str | None:
+                    pending_line: str | None = None
 
-                with (
-                    Path(output_path).open("w", encoding="utf-8", newline="")
-                    if output_path is not None
-                    else nullcontext()
-                ) as handle:
+                    async def read_line_with_timeout() -> bytes:
+                        remaining = deadline - loop.time()
+                        if remaining <= 0:
+                            raise asyncio.TimeoutError
+                        return await asyncio.wait_for(
+                            stdout.readline(), timeout=remaining
+                        )
+
                     try:
                         while True:
                             line_bytes = await read_line_with_timeout()
@@ -202,7 +206,6 @@ class ClickHouseCLIConnector(BaseCLIConnector):
                             if pending_line is not None:
                                 emit_line(pending_line)
                             pending_line = line
-
                     except asyncio.TimeoutError:
                         logger.warning(
                             "Query timeout - terminating clickhouse-client process"
@@ -217,34 +220,57 @@ class ClickHouseCLIConnector(BaseCLIConnector):
                         raise TimeoutError(
                             f"clickhouse-client: Query timeout after {self.query_timeout}s"
                         )
+                    return pending_line
 
-                try:
-                    await asyncio.wait_for(process.wait(), timeout=1.0)
-                except asyncio.TimeoutError:
-                    logger.error("clickhouse-client process did not terminate cleanly")
-                    process.kill()
-                    await process.wait()
+                async def finalize_process(
+                    emit_line: Callable[[str], None], pending_line: str | None
+                ) -> None:
+                    try:
+                        await asyncio.wait_for(process.wait(), timeout=1.0)
+                    except asyncio.TimeoutError:
+                        logger.error(
+                            "clickhouse-client process did not terminate cleanly"
+                        )
+                        process.kill()
+                        await process.wait()
 
-                if not stderr_task.done():
-                    stderr = await stderr_task
-                else:
-                    stderr = stderr_task.result()
+                    try:
+                        stderr = (
+                            await stderr_task
+                            if not stderr_task.done()
+                            else stderr_task.result()
+                        )
+                    except asyncio.CancelledError:
+                        stderr = b""
 
-                returncode = process.returncode
-                if returncode is None:
-                    logger.debug(
-                        "clickhouse-client process still running after wait(); treating as successful termination"
-                    )
-                if returncode not in (0, None):
-                    error_msg = stderr.decode() if stderr else "Unknown error"
-                    logger.error(f"clickhouse-client error: {error_msg}")
-                    raise RuntimeError(f"clickhouse-client: {error_msg}")
+                    returncode = process.returncode
+                    if returncode is None:
+                        logger.debug(
+                            "clickhouse-client process still running after wait(); treating as successful termination"
+                        )
+                    if returncode not in (0, None):
+                        error_msg = stderr.decode() if stderr else "Unknown error"
+                        logger.error(f"clickhouse-client error: {error_msg}")
+                        raise RuntimeError(f"clickhouse-client: {error_msg}")
 
-                if pending_line not in (None, ""):
-                    emit_line(pending_line)
+                    if pending_line not in (None, ""):
+                        emit_line(pending_line)
 
                 if output_path is None:
+                    pending_line = await stream_output(lines.append)
+                    await finalize_process(lines.append, pending_line)
                     return "\n".join(lines)
+
+                wrote_content = False
+
+                def emit_file_line(line: str) -> None:
+                    nonlocal wrote_content
+                    wrote_content = write_tsv_text_line(handle, line, wrote_content)
+
+                assert output_path is not None
+                with Path(output_path).open("w", encoding="utf-8", newline="") as handle:
+                    pending_line = await stream_output(emit_file_line)
+                    await finalize_process(emit_file_line, pending_line)
                 return None
 
             except FileNotFoundError:

--- a/src/mcp_read_only_sql/connectors/clickhouse/python.py
+++ b/src/mcp_read_only_sql/connectors/clickhouse/python.py
@@ -234,7 +234,7 @@ class ClickHousePythonConnector(BaseConnector):
         port: int,
         database: str,
         query: str,
-        original_port: int = None,
+        original_port: Optional[int] = None,
         is_ssh_tunnel: bool = False,
         output_path: Optional[str] = None,
     ) -> str:
@@ -294,9 +294,9 @@ class ClickHousePythonConnector(BaseConnector):
         port: int,
         database: str,
         query: str,
-        original_port: int = None,
+        original_port: Optional[int] = None,
         is_ssh_tunnel: bool = False,
-        output_path: Optional[str] = None,
+        output_path: str = "",
     ) -> None:
         """Execute query synchronously and stream raw TSV output to a file."""
         client = None

--- a/src/mcp_read_only_sql/connectors/postgresql/cli.py
+++ b/src/mcp_read_only_sql/connectors/postgresql/cli.py
@@ -1,9 +1,9 @@
 import asyncio
 import logging
 import os
-from contextlib import nullcontext, suppress
+from contextlib import suppress
 from pathlib import Path
-from typing import Optional
+from typing import Callable, Optional
 
 from ..base_cli import BaseCLIConnector
 from ...utils.sql_guard import sanitize_read_only_sql, ReadOnlyQueryError
@@ -22,9 +22,10 @@ class PostgreSQLCLIConnector(BaseCLIConnector):
         self, query: str, database: Optional[str] = None, server: Optional[str] = None
     ) -> str:
         """Execute a read-only query using psql and return raw TSV output"""
-        return await self._run_query(
+        result = await self._run_query(
             query, database=database, server=server, output_path=None
         )
+        return result if result is not None else ""
 
     async def execute_query_to_file(
         self,
@@ -95,7 +96,7 @@ class PostgreSQLCLIConnector(BaseCLIConnector):
                 wrapped_query,  # Query to execute
             ]
 
-            async def run_psql(env_vars):
+            async def run_psql(env_vars: dict[str, str]) -> Optional[str]:
                 process = await asyncio.create_subprocess_exec(
                     *cmd,
                     stdout=asyncio.subprocess.PIPE,
@@ -104,32 +105,28 @@ class PostgreSQLCLIConnector(BaseCLIConnector):
                 )
 
                 stdout = process.stdout
-                stderr_task = asyncio.create_task(process.stderr.read())
-                lines = [] if output_path is None else None
-                pending_line = None
-                wrote_content = False
+                stderr_stream = process.stderr
+                if stdout is None or stderr_stream is None:
+                    process.kill()
+                    await process.wait()
+                    raise RuntimeError("psql: failed to create subprocess pipes")
 
-                def emit_line(line: str) -> None:
-                    nonlocal wrote_content
-                    if output_path is None:
-                        lines.append(line)
-                    else:
-                        wrote_content = write_tsv_text_line(handle, line, wrote_content)
-
+                stderr_task = asyncio.create_task(stderr_stream.read())
+                lines: list[str] = []
                 loop = asyncio.get_event_loop()
                 deadline = loop.time() + self.query_timeout
 
-                async def read_line_with_timeout():
-                    remaining = deadline - loop.time()
-                    if remaining <= 0:
-                        raise asyncio.TimeoutError
-                    return await asyncio.wait_for(stdout.readline(), timeout=remaining)
+                async def stream_output(emit_line: Callable[[str], None]) -> str | None:
+                    pending_line: str | None = None
 
-                with (
-                    Path(output_path).open("w", encoding="utf-8", newline="")
-                    if output_path is not None
-                    else nullcontext()
-                ) as handle:
+                    async def read_line_with_timeout() -> bytes:
+                        remaining = deadline - loop.time()
+                        if remaining <= 0:
+                            raise asyncio.TimeoutError
+                        return await asyncio.wait_for(
+                            stdout.readline(), timeout=remaining
+                        )
+
                     try:
                         while True:
                             line_bytes = await read_line_with_timeout()
@@ -150,7 +147,6 @@ class PostgreSQLCLIConnector(BaseCLIConnector):
                             if pending_line is not None:
                                 emit_line(pending_line)
                             pending_line = line
-
                     except asyncio.TimeoutError:
                         logger.warning("Query timeout - terminating psql process")
                         process.kill()
@@ -162,7 +158,11 @@ class PostgreSQLCLIConnector(BaseCLIConnector):
                         raise TimeoutError(
                             f"psql: Query timeout after {self.query_timeout}s"
                         )
+                    return pending_line
 
+                async def finalize_process(
+                    emit_line: Callable[[str], None], pending_line: str | None
+                ) -> None:
                     try:
                         await asyncio.wait_for(process.wait(), timeout=1.0)
                     except asyncio.TimeoutError:
@@ -170,11 +170,14 @@ class PostgreSQLCLIConnector(BaseCLIConnector):
                         process.kill()
                         await process.wait()
 
-                    if not stderr_task.done():
-                        stderr = await stderr_task
-                    else:
-                        stderr = stderr_task.result()
-
+                    try:
+                        stderr = (
+                            await stderr_task
+                            if not stderr_task.done()
+                            else stderr_task.result()
+                        )
+                    except asyncio.CancelledError:
+                        stderr = b""
                     returncode = process.returncode
                     if returncode is None:
                         logger.debug(
@@ -188,9 +191,22 @@ class PostgreSQLCLIConnector(BaseCLIConnector):
                     if pending_line not in (None, ""):
                         emit_line(pending_line)
 
-                    if output_path is None:
-                        return "\n".join(lines)
-                    return None
+                if output_path is None:
+                    pending_line = await stream_output(lines.append)
+                    await finalize_process(lines.append, pending_line)
+                    return "\n".join(lines)
+
+                wrote_content = False
+
+                def emit_file_line(line: str) -> None:
+                    nonlocal wrote_content
+                    wrote_content = write_tsv_text_line(handle, line, wrote_content)
+
+                assert output_path is not None
+                with Path(output_path).open("w", encoding="utf-8", newline="") as handle:
+                    pending_line = await stream_output(emit_file_line)
+                    await finalize_process(emit_file_line, pending_line)
+                return None
 
             use_pgoptions = getattr(self.connection, "cli_requires_pgoptions", True)
             attempts = [True] if not use_pgoptions else [True, False]

--- a/src/mcp_read_only_sql/connectors/postgresql/python.py
+++ b/src/mcp_read_only_sql/connectors/postgresql/python.py
@@ -90,10 +90,13 @@ class PostgreSQLPythonConnector(BaseConnector):
             raise TimeoutError(
                 f"PostgreSQL: Operation exceeded combined timeout of {self.connection_timeout + self.query_timeout} seconds"
             )
-        except psycopg_errors.QueryCanceled as e:
-            logger.error(f"PostgreSQL query canceled: {e}")
-            raise TimeoutError(f"PostgreSQL: {e}")
         except psycopg2.Error as e:
+            query_canceled_type = getattr(psycopg_errors, "QueryCanceled", None)
+            if isinstance(query_canceled_type, type) and isinstance(
+                e, query_canceled_type
+            ):
+                logger.error(f"PostgreSQL query canceled: {e}")
+                raise TimeoutError(f"PostgreSQL: {e}")
             # Database-specific errors get prefixed
             logger.error(f"PostgreSQL database error: {e}")
             raise RuntimeError(f"PostgreSQL: {e}")

--- a/src/mcp_read_only_sql/tools/test_ssh_tunnel.py
+++ b/src/mcp_read_only_sql/tools/test_ssh_tunnel.py
@@ -48,6 +48,8 @@ async def test_ssh_tunnels(
 
         for name, connection in ssh_connections.items():
             ssh_config = connection.ssh_tunnel
+            if ssh_config is None:
+                continue
             impl = connection.implementation
             servers = connection.servers
 

--- a/src/mcp_read_only_sql/utils/json_serializer.py
+++ b/src/mcp_read_only_sql/utils/json_serializer.py
@@ -10,16 +10,16 @@ from typing import Any
 class DatabaseJSONEncoder(json.JSONEncoder):
     """Simple JSON encoder that converts unknown types to strings."""
 
-    def default(self, obj: Any) -> Any:
+    def default(self, o: Any) -> Any:
         """Convert non-JSON-serializable objects to strings."""
         # Try to convert numeric types to float
         try:
-            return float(obj)
+            return float(o)
         except (TypeError, ValueError):
             pass
 
         # For any other non-serializable type, convert to string
-        return str(obj)
+        return str(o)
 
 
 def serialize_result(result: dict) -> str:

--- a/src/mcp_read_only_sql/utils/ssh_tunnel.py
+++ b/src/mcp_read_only_sql/utils/ssh_tunnel.py
@@ -1,8 +1,9 @@
 import asyncio
 import logging
-import socket
 import select
+import socket
 import threading
+
 import paramiko
 
 logger = logging.getLogger(__name__)
@@ -28,7 +29,7 @@ class SSHTunnel:
         self.ssh_timeout = ssh_config.ssh_timeout or self.DEFAULT_SSH_TIMEOUT
         self.ssh_client = None
         self.transport = None
-        self.local_port = None
+        self.local_port: int | None = None
         self.tunnel_thread = None
         self._lock = threading.Lock()
         self._stop_event = threading.Event()
@@ -49,6 +50,7 @@ class SSHTunnel:
         """Synchronous tunnel start using Paramiko"""
         with self._lock:
             if self.ssh_client and self.transport and self.transport.is_active():
+                assert self.local_port is not None
                 return self.local_port
 
             tunnel_established = False
@@ -149,6 +151,7 @@ class SSHTunnel:
                     f"SSH tunnel established: localhost:{self.local_port} -> {remote_host}:{remote_port}"
                 )
                 tunnel_established = True
+                assert self.local_port is not None
                 return self.local_port
 
             except ValueError as e:

--- a/src/mcp_read_only_sql/utils/timeout_wrapper.py
+++ b/src/mcp_read_only_sql/utils/timeout_wrapper.py
@@ -2,8 +2,8 @@
 
 import asyncio
 import logging
-from typing import Any, Dict, Callable
 from functools import wraps
+from typing import Any, Awaitable, Callable, Dict
 
 logger = logging.getLogger(__name__)
 
@@ -74,11 +74,11 @@ def hard_timeout(timeout_seconds: float = 30.0):
             ...
     """
 
-    def decorator(func: Callable) -> Callable:
+    def decorator(func: Callable[..., Awaitable[Any]]) -> Callable[..., Awaitable[Any]]:
         @wraps(func)
         async def wrapper(*args, **kwargs):
             # Try to get operation name from function
-            operation_name = func.__name__
+            operation_name = getattr(func, "__name__", "operation")
 
             # Create the coroutine
             coro = func(*args, **kwargs)
@@ -115,12 +115,13 @@ class HardTimeoutMixin:
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         # Get hard timeout from config or use default
-        if hasattr(self, "config"):
-            self.hard_timeout = self.config.get(
-                "hard_timeout", self.DEFAULT_HARD_TIMEOUT
+        config = getattr(self, "config", None)
+        if isinstance(config, dict):
+            self.hard_timeout = float(
+                config.get("hard_timeout", self.DEFAULT_HARD_TIMEOUT)
             )
-        else:
-            self.hard_timeout = self.DEFAULT_HARD_TIMEOUT
+            return
+        self.hard_timeout = self.DEFAULT_HARD_TIMEOUT
 
     async def execute_with_timeout(
         self, coro, operation_name: str = "query"


### PR DESCRIPTION
## Summary
- add `ty` and expand it from an initial partial rollout to the full SQL `src/` tree
- fix typing and subprocess/output handling in SQL config, connector, SSH, and utility modules so the full package passes
- refresh `AGENTS.md` to match the current SQL workflow and tooling

## Why
- move from partial type coverage to a clean full-source `ty` pass
- document contributor guidance that matches the current Ruff/ty and test setup

## Validation
- `uv run --extra dev ruff check .`
- `uv run --extra dev ty check`
