### PR TITLE
Add vulture dev dependency and config

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,6 +40,7 @@ dev = [
     "black>=23.0.0",
     "ruff>=0.1.0",
     "ty>=0.0.28",
+    "vulture>=2.16",
 ]
 
 [build-system]
@@ -54,3 +55,10 @@ packages = ["src/mcp_read_only_sql"]
 
 [tool.ty.src]
 include = ["src"]
+
+[tool.vulture]
+paths = ["src", "tests"]
+exclude = [".venv", "venv", "build", "dist", "node_modules", "__pycache__", "site-packages"]
+ignore_decorators = ["@*.tool*", "@pytest.fixture"]
+ignore_names = ["pytest_*"]
+min_confidence = 80


### PR DESCRIPTION
## Summary
- add `vulture` as a development dependency
- add a conservative `[tool.vulture]` configuration with scoped paths, exclusions, and framework/test ignores
- keep this change limited to tool setup; cleanup from `vulture` findings will happen in a follow-up task

## Testing
- not run; dependency/config-only change