### PR TITLE
Release 0.2.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project aims to follow [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+## [0.2.3] - 2026-04-21
+
+### Added
+
+- Added hot-reload regression tests covering connection add/change/remove flows, invalid live edits, and config changes that happen during a reload attempt.
+
+### Fixed
+
+- Reloaded `connections.yaml` automatically before both `list_connections` and `run_query_read_only`, without requiring an MCP server restart.
+- Kept hot-reload state atomic by building connectors from a single file snapshot and only storing a config marker for the exact snapshot that was actually loaded.
+- Preserved the last known good connections when live config edits are invalid or the config file is temporarily missing, while continuing to retry reloads on later tool calls.
+
 ## [0.2.2] - 2026-04-03
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "mcp-read-only-sql"
-version = "0.2.2"
+version = "0.2.3"
 description = "MCP server for read-only SQL queries supporting PostgreSQL and ClickHouse"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/src/mcp_read_only_sql/config/__init__.py
+++ b/src/mcp_read_only_sql/config/__init__.py
@@ -3,6 +3,12 @@ Configuration module for connection management
 """
 
 from .connection import Connection, Server, SSHTunnelConfig
-from .loader import load_connections
+from .loader import load_connections, load_connections_from_text
 
-__all__ = ["Connection", "Server", "SSHTunnelConfig", "load_connections"]
+__all__ = [
+    "Connection",
+    "Server",
+    "SSHTunnelConfig",
+    "load_connections",
+    "load_connections_from_text",
+]

--- a/src/mcp_read_only_sql/config/loader.py
+++ b/src/mcp_read_only_sql/config/loader.py
@@ -8,29 +8,13 @@ import yaml
 from .connection import Connection
 
 
-def load_connections(yaml_path: str | Path) -> Dict[str, Connection]:
-    """
-    Load and validate all connections from YAML configuration file.
-
-    Args:
-        yaml_path: Path to connections.yaml file
-
-    Returns:
-        Dictionary mapping connection name to Connection object
-
-    Raises:
-        FileNotFoundError: If YAML file doesn't exist
-        ValueError: If configuration is invalid (includes all validation errors)
-    """
-    yaml_file = Path(yaml_path).expanduser()
-    if not yaml_file.exists():
-        raise FileNotFoundError(f"Configuration file not found: {yaml_path}")
-
-    with open(yaml_file, encoding="utf-8") as f:
-        raw_configs = yaml.safe_load(f)
-
+def _build_connections_from_raw_configs(
+    raw_configs: Any, source: str | Path
+) -> Dict[str, Connection]:
+    """Validate parsed YAML data and return Connection objects."""
+    source_name = str(source)
     if not raw_configs:
-        raise ValueError(f"Configuration file is empty: {yaml_path}")
+        raise ValueError(f"Configuration file is empty: {source_name}")
 
     if not isinstance(raw_configs, list):
         raise ValueError("Configuration file must contain a list of connections")
@@ -64,3 +48,41 @@ def load_connections(yaml_path: str | Path) -> Dict[str, Connection]:
         raise ValueError(error_msg)
 
     return connections
+
+
+def load_connections_from_text(
+    yaml_text: str, source: str | Path = "<memory>"
+) -> Dict[str, Connection]:
+    """
+    Load and validate connections from a YAML text snapshot.
+
+    Args:
+        yaml_text: Raw YAML document content
+        source: Source label used in validation errors
+    """
+    raw_configs = yaml.safe_load(yaml_text)
+    return _build_connections_from_raw_configs(raw_configs, source)
+
+
+def load_connections(yaml_path: str | Path) -> Dict[str, Connection]:
+    """
+    Load and validate all connections from YAML configuration file.
+
+    Args:
+        yaml_path: Path to connections.yaml file
+
+    Returns:
+        Dictionary mapping connection name to Connection object
+
+    Raises:
+        FileNotFoundError: If YAML file doesn't exist
+        ValueError: If configuration is invalid (includes all validation errors)
+    """
+    yaml_file = Path(yaml_path).expanduser()
+    if not yaml_file.exists():
+        raise FileNotFoundError(f"Configuration file not found: {yaml_path}")
+
+    with open(yaml_file, encoding="utf-8") as f:
+        yaml_text = f.read()
+
+    return load_connections_from_text(yaml_text, yaml_file)

--- a/src/mcp_read_only_sql/server.py
+++ b/src/mcp_read_only_sql/server.py
@@ -14,13 +14,13 @@ import re
 import sys
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Callable, Dict, List, Optional
+from typing import Callable, Dict, List, Optional, TypeAlias
 from uuid import uuid4
 
 from mcp.server.fastmcp import FastMCP
 
 from . import __version__
-from .config import dbeaver_import, load_connections
+from .config import Connection, dbeaver_import, load_connections_from_text
 from .config.connection import (
     DEFAULT_CONNECTION_TIMEOUT,
     DEFAULT_QUERY_TIMEOUT,
@@ -42,6 +42,7 @@ logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
 RESULT_FILE_NAME_RE = re.compile(r"[^A-Za-z0-9._-]+")
 RESULT_DIR_HASH_BYTES = 6
+ConfigMarker: TypeAlias = tuple[int, int] | None
 SAMPLE_CONNECTIONS_YAML = (
     files("mcp_read_only_sql")
     .joinpath("connections.yaml.sample")
@@ -81,6 +82,7 @@ class ReadOnlySQLServer:
     def __init__(self, runtime_paths: RuntimePaths):
         self.runtime_paths = runtime_paths
         self.connections: Dict[str, BaseConnector] = {}
+        self._connections_config_marker: ConfigMarker = None
 
         self.runtime_paths.ensure_directories()
         self.mcp = FastMCP("mcp-read-only-sql")
@@ -120,52 +122,102 @@ class ReadOnlySQLServer:
         raise FileExistsError("Could not allocate a unique managed result file")
 
     def _load_connections(self) -> None:
+        """Load connections during startup and remember the current config marker."""
         try:
-            connections_config = load_connections(self.runtime_paths.connections_file)
-
-            errors = []
-
-            for conn_name, connection in connections_config.items():
-                try:
-                    if connection.db_type == "postgresql":
-                        if connection.implementation == "cli":
-                            self.connections[conn_name] = PostgreSQLCLIConnector(
-                                connection
-                            )
-                        else:
-                            self.connections[conn_name] = PostgreSQLPythonConnector(
-                                connection
-                            )
-                    elif connection.db_type == "clickhouse":
-                        if connection.implementation == "cli":
-                            self.connections[conn_name] = ClickHouseCLIConnector(
-                                connection
-                            )
-                        else:
-                            self.connections[conn_name] = ClickHousePythonConnector(
-                                connection
-                            )
-
-                    logger.info(
-                        "Loaded connection: %s (%s, %s)",
-                        conn_name,
-                        connection.db_type,
-                        connection.implementation,
-                    )
-
-                except ImportError as exc:
-                    errors.append(f"  - {conn_name}: Missing dependency - {exc}")
-                except Exception as exc:
-                    errors.append(f"  - {conn_name}: {exc}")
-
-            if errors:
-                error_msg = "Failed to load some connections:\n" + "\n".join(errors)
-                logger.error(error_msg)
-                raise RuntimeError(error_msg)
-
+            self.connections, self._connections_config_marker = self._build_connections()
         except Exception as exc:
             logger.error("Failed to load connections: %s", exc)
             raise
+
+    def _read_connections_config_marker(self) -> ConfigMarker:
+        """Return a lightweight marker for the current connections.yaml state."""
+        try:
+            stat_result = self.runtime_paths.connections_file.stat()
+        except FileNotFoundError:
+            return None
+        return (stat_result.st_mtime_ns, stat_result.st_size)
+
+    def _build_connector(self, connection: Connection) -> BaseConnector:
+        """Create the correct connector implementation for a validated connection."""
+        if connection.db_type == "postgresql":
+            if connection.implementation == "cli":
+                return PostgreSQLCLIConnector(connection)
+            return PostgreSQLPythonConnector(connection)
+        if connection.db_type == "clickhouse":
+            if connection.implementation == "cli":
+                return ClickHouseCLIConnector(connection)
+            return ClickHousePythonConnector(connection)
+        raise ValueError(f"Unsupported database type: {connection.db_type}")
+
+    def _read_connections_config_snapshot(self) -> tuple[str, ConfigMarker]:
+        """Read connections.yaml once and return content with its matching marker."""
+        yaml_file = self.runtime_paths.connections_file.expanduser()
+        try:
+            with open(yaml_file, encoding="utf-8") as f:
+                yaml_text = f.read()
+                stat_result = os.fstat(f.fileno())
+        except FileNotFoundError as exc:
+            raise FileNotFoundError(
+                f"Configuration file not found: {self.runtime_paths.connections_file}"
+            ) from exc
+        return yaml_text, (stat_result.st_mtime_ns, stat_result.st_size)
+
+    def _build_connections(self) -> tuple[Dict[str, BaseConnector], ConfigMarker]:
+        """Build a fresh connector map from one config snapshot without mutating state."""
+        yaml_text, marker = self._read_connections_config_snapshot()
+        connections_config = load_connections_from_text(
+            yaml_text, self.runtime_paths.connections_file
+        )
+        built_connections: Dict[str, BaseConnector] = {}
+        errors = []
+
+        for conn_name, connection in connections_config.items():
+            try:
+                built_connections[conn_name] = self._build_connector(connection)
+                logger.info(
+                    "Loaded connection: %s (%s, %s)",
+                    conn_name,
+                    connection.db_type,
+                    connection.implementation,
+                )
+            except ImportError as exc:
+                errors.append(f"  - {conn_name}: Missing dependency - {exc}")
+            except Exception as exc:
+                errors.append(f"  - {conn_name}: {exc}")
+
+        if errors:
+            error_msg = "Failed to load some connections:\n" + "\n".join(errors)
+            logger.error(error_msg)
+            raise RuntimeError(error_msg)
+
+        return built_connections, marker
+
+    def _reload_connections_if_needed(self) -> None:
+        """Reload connections.yaml if it changed, preserving the last good config on errors."""
+        previous_marker = self._connections_config_marker
+        current_marker = self._read_connections_config_marker()
+        if current_marker == previous_marker:
+            return
+
+        logger.info("Detected change in %s; reloading connections", self.runtime_paths.connections_file)
+        try:
+            new_connections, new_marker = self._build_connections()
+        except Exception as exc:
+            logger.warning(
+                "Failed to reload connections from %s; keeping %s previously loaded connection(s): %s",
+                self.runtime_paths.connections_file,
+                len(self.connections),
+                exc,
+            )
+            return
+
+        self.connections = new_connections
+        self._connections_config_marker = new_marker
+        logger.info(
+            "Reloaded %s connection(s) from %s",
+            len(self.connections),
+            self.runtime_paths.connections_file,
+        )
 
     def _setup_tools(self) -> None:
         """Setup MCP tools using FastMCP decorators."""
@@ -192,6 +244,7 @@ class ReadOnlySQLServer:
                 directory for this server instance. Successful query results
                 are retained there until removed by the operator.
             """
+            self._reload_connections_if_needed()
             if connection_name not in self.connections:
                 raise ValueError(
                     f"Connection '{connection_name}' not found. Available connections: {', '.join(self.connections.keys())}"
@@ -223,6 +276,7 @@ class ReadOnlySQLServer:
                 hosts for each connection, while ``database`` and ``databases``
                 describe the default database and allowed database list.
             """
+            self._reload_connections_if_needed()
             conn_list = []
 
             for conn_name, connector in self.connections.items():

--- a/tests/test_connections_reload.py
+++ b/tests/test_connections_reload.py
@@ -1,0 +1,350 @@
+#!/usr/bin/env python3
+"""Tests for runtime reloading of connections.yaml."""
+
+import logging
+from pathlib import Path
+
+import pytest
+import yaml
+from mcp.server.fastmcp.exceptions import ToolError
+
+import mcp_read_only_sql.server as server_module
+from mcp_read_only_sql.config import Connection
+from mcp_read_only_sql.connectors.base import BaseConnector
+from mcp_read_only_sql.runtime_paths import RuntimePaths
+from mcp_read_only_sql.server import ReadOnlySQLServer
+
+
+class ReloadTestConnector(BaseConnector):
+    """Connector stub that surfaces the currently loaded config in TSV output."""
+
+    async def execute_query(self, query: str, database=None, server=None) -> str:  # type: ignore[override]
+        selected_server = self._select_server(server)
+        selected_database = self._resolve_database(database)
+        return (
+            "connection\tserver\tdatabase\tuser\n"
+            f"{self.name}\t{selected_server.host}\t{selected_database}\t{self.username}"
+        )
+
+
+def make_runtime_paths(tmp_path: Path) -> RuntimePaths:
+    """Create isolated runtime paths for reload tests."""
+    runtime_paths = RuntimePaths(
+        config_dir=tmp_path / "config",
+        state_dir=tmp_path / "state",
+        cache_dir=tmp_path / "cache",
+    )
+    runtime_paths.ensure_directories()
+    return runtime_paths
+
+
+def write_connections_file(path: Path, connections: list[dict[str, object]]) -> None:
+    """Write a YAML connections file for a reload scenario."""
+    path.write_text(
+        yaml.safe_dump(connections, sort_keys=False),
+        encoding="utf-8",
+    )
+
+
+def parse_tsv_rows(tsv_text: str) -> list[dict[str, str]]:
+    """Parse the server's tab-separated list_connections response."""
+    lines = tsv_text.splitlines()
+    headers = lines[0].split("\t")
+    rows: list[dict[str, str]] = []
+    for line in lines[1:]:
+        if not line:
+            continue
+        rows.append(dict(zip(headers, line.split("\t"))))
+    return rows
+
+
+def apply_stub_connectors(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Route server connector construction to the in-memory reload test stub."""
+    monkeypatch.setattr(
+        server_module, "PostgreSQLCLIConnector", ReloadTestConnector
+    )
+    monkeypatch.setattr(
+        server_module, "PostgreSQLPythonConnector", ReloadTestConnector
+    )
+    monkeypatch.setattr(
+        server_module, "ClickHouseCLIConnector", ReloadTestConnector
+    )
+    monkeypatch.setattr(
+        server_module, "ClickHousePythonConnector", ReloadTestConnector
+    )
+
+
+def count_load_connections(monkeypatch: pytest.MonkeyPatch) -> dict[str, int]:
+    """Wrap load_connections so tests can assert whether reloads happened."""
+    real_load_connections = server_module.load_connections_from_text
+    call_counter = {"count": 0}
+
+    def wrapped_load_connections(
+        yaml_text: str, source: str | Path = "<memory>"
+    ) -> dict[str, Connection]:
+        call_counter["count"] += 1
+        return real_load_connections(yaml_text, source)
+
+    monkeypatch.setattr(
+        server_module, "load_connections_from_text", wrapped_load_connections
+    )
+    return call_counter
+
+
+async def list_connections(server: ReadOnlySQLServer) -> list[dict[str, str]]:
+    """Call list_connections directly on the in-process FastMCP server."""
+    result = await server.mcp._tool_manager.call_tool(
+        "list_connections",
+        {},
+        convert_result=False,
+    )
+    assert isinstance(result, str)
+    return parse_tsv_rows(result)
+
+
+async def run_query(server: ReadOnlySQLServer, connection_name: str) -> Path:
+    """Run a query against the in-process FastMCP server and return the TSV path."""
+    result = await server.mcp._tool_manager.call_tool(
+        "run_query_read_only",
+        {"connection_name": connection_name, "query": "SELECT 1"},
+        convert_result=False,
+    )
+    assert isinstance(result, str)
+    return Path(result)
+
+
+@pytest.mark.anyio
+async def test_tools_reload_connections_after_config_changes(tmp_path, monkeypatch):
+    apply_stub_connectors(monkeypatch)
+    runtime_paths = make_runtime_paths(tmp_path)
+    write_connections_file(
+        runtime_paths.connections_file,
+        [
+            {
+                "connection_name": "alpha",
+                "type": "postgresql",
+                "implementation": "cli",
+                "servers": ["alpha-db:5432"],
+                "db": "analytics",
+                "username": "alpha_user",
+                "password": "secret",
+            },
+            {
+                "connection_name": "beta",
+                "type": "postgresql",
+                "implementation": "cli",
+                "servers": ["beta-db:5432"],
+                "db": "warehouse",
+                "username": "beta_user",
+                "password": "secret",
+            },
+        ],
+    )
+    server = ReadOnlySQLServer(runtime_paths)
+
+    initial_connections = await list_connections(server)
+    assert [row["name"] for row in initial_connections] == ["alpha", "beta"]
+
+    write_connections_file(
+        runtime_paths.connections_file,
+        [
+            {
+                "connection_name": "beta",
+                "type": "postgresql",
+                "implementation": "cli",
+                "servers": ["beta-db-v2:5432"],
+                "db": "warehouse",
+                "username": "beta_user_v2",
+                "password": "secret",
+            },
+            {
+                "connection_name": "gamma",
+                "type": "postgresql",
+                "implementation": "cli",
+                "servers": ["gamma-db:5432"],
+                "db": "warehouse",
+                "username": "gamma_user",
+                "password": "secret",
+            },
+        ],
+    )
+
+    reloaded_connections = await list_connections(server)
+    assert [row["name"] for row in reloaded_connections] == ["beta", "gamma"]
+    reloaded_map = {row["name"]: row for row in reloaded_connections}
+    assert reloaded_map["beta"]["servers"] == "beta-db-v2"
+    assert reloaded_map["beta"]["user"] == "beta_user_v2"
+
+    with pytest.raises(ToolError, match="Connection 'alpha' not found"):
+        await run_query(server, "alpha")
+
+    gamma_result = await run_query(server, "gamma")
+    assert gamma_result.read_text(encoding="utf-8").splitlines() == [
+        "connection\tserver\tdatabase\tuser",
+        "gamma\tgamma-db\twarehouse\tgamma_user",
+    ]
+
+
+@pytest.mark.anyio
+async def test_reload_skips_unchanged_config(tmp_path, monkeypatch):
+    apply_stub_connectors(monkeypatch)
+    load_calls = count_load_connections(monkeypatch)
+    runtime_paths = make_runtime_paths(tmp_path)
+    write_connections_file(
+        runtime_paths.connections_file,
+        [
+            {
+                "connection_name": "alpha",
+                "type": "postgresql",
+                "implementation": "cli",
+                "servers": ["alpha-db:5432"],
+                "db": "analytics",
+                "username": "alpha_user",
+                "password": "secret",
+            }
+        ],
+    )
+    server = ReadOnlySQLServer(runtime_paths)
+
+    assert load_calls["count"] == 1
+
+    await list_connections(server)
+    await list_connections(server)
+    await run_query(server, "alpha")
+
+    assert load_calls["count"] == 1
+
+
+@pytest.mark.anyio
+async def test_invalid_reload_keeps_last_good_connections(
+    tmp_path, monkeypatch, caplog
+):
+    apply_stub_connectors(monkeypatch)
+    load_calls = count_load_connections(monkeypatch)
+    runtime_paths = make_runtime_paths(tmp_path)
+    write_connections_file(
+        runtime_paths.connections_file,
+        [
+            {
+                "connection_name": "alpha",
+                "type": "postgresql",
+                "implementation": "cli",
+                "servers": ["alpha-db:5432"],
+                "db": "analytics",
+                "username": "alpha_user",
+                "password": "secret",
+            }
+        ],
+    )
+    server = ReadOnlySQLServer(runtime_paths)
+    caplog.set_level(logging.WARNING)
+
+    runtime_paths.connections_file.write_text("invalid: true\n", encoding="utf-8")
+
+    preserved_connections = await list_connections(server)
+    assert [row["name"] for row in preserved_connections] == ["alpha"]
+
+    alpha_result = await run_query(server, "alpha")
+    assert alpha_result.read_text(encoding="utf-8").splitlines() == [
+        "connection\tserver\tdatabase\tuser",
+        "alpha\talpha-db\tanalytics\talpha_user",
+    ]
+
+    await list_connections(server)
+
+    assert load_calls["count"] == 4
+    assert "keeping 1 previously loaded connection(s)" in caplog.text
+
+
+@pytest.mark.anyio
+async def test_reload_retries_after_file_changes_during_reload(tmp_path, monkeypatch):
+    apply_stub_connectors(monkeypatch)
+    runtime_paths = make_runtime_paths(tmp_path)
+    write_connections_file(
+        runtime_paths.connections_file,
+        [
+            {
+                "connection_name": "alpha",
+                "type": "postgresql",
+                "implementation": "cli",
+                "servers": ["alpha-db:5432"],
+                "db": "analytics",
+                "username": "alpha_user",
+                "password": "secret",
+            }
+        ],
+    )
+    server = ReadOnlySQLServer(runtime_paths)
+
+    beta_connections = [
+        {
+            "connection_name": "beta",
+            "type": "postgresql",
+            "implementation": "cli",
+            "servers": ["beta-db:5432"],
+            "db": "warehouse",
+            "username": "beta_user",
+            "password": "secret",
+        }
+    ]
+    gamma_connections = [
+        {
+            "connection_name": "gamma",
+            "type": "postgresql",
+            "implementation": "cli",
+            "servers": ["gamma-db:5432"],
+            "db": "warehouse",
+            "username": "gamma_user",
+            "password": "secret",
+        }
+    ]
+    write_connections_file(runtime_paths.connections_file, beta_connections)
+
+    original_build_connector = server._build_connector
+    triggered_reload_edit = False
+
+    def build_connector_and_mutate_file(connection: Connection) -> BaseConnector:
+        nonlocal triggered_reload_edit
+        connector = original_build_connector(connection)
+        if not triggered_reload_edit and connection.name == "beta":
+            write_connections_file(runtime_paths.connections_file, gamma_connections)
+            triggered_reload_edit = True
+        return connector
+
+    monkeypatch.setattr(server, "_build_connector", build_connector_and_mutate_file)
+
+    beta_result = await list_connections(server)
+    assert [row["name"] for row in beta_result] == ["beta"]
+
+    gamma_result = await list_connections(server)
+    assert [row["name"] for row in gamma_result] == ["gamma"]
+
+
+@pytest.mark.anyio
+async def test_missing_connections_file_keeps_last_good_config(
+    tmp_path, monkeypatch, caplog
+):
+    apply_stub_connectors(monkeypatch)
+    runtime_paths = make_runtime_paths(tmp_path)
+    write_connections_file(
+        runtime_paths.connections_file,
+        [
+            {
+                "connection_name": "alpha",
+                "type": "postgresql",
+                "implementation": "cli",
+                "servers": ["alpha-db:5432"],
+                "db": "analytics",
+                "username": "alpha_user",
+                "password": "secret",
+            }
+        ],
+    )
+    server = ReadOnlySQLServer(runtime_paths)
+    caplog.set_level(logging.WARNING)
+
+    runtime_paths.connections_file.unlink()
+
+    preserved_connections = await list_connections(server)
+    assert [row["name"] for row in preserved_connections] == ["alpha"]
+    assert "Failed to reload connections" in caplog.text

--- a/tests/test_run_query_file_output.py
+++ b/tests/test_run_query_file_output.py
@@ -30,6 +30,7 @@ def build_stub_server(
     server = ReadOnlySQLServer.__new__(ReadOnlySQLServer)
     server.runtime_paths = runtime_paths
     server.connections = {connector.name: connector}
+    server._connections_config_marker = None
     server.mcp = FastMCP("mcp-read-only-sql-test")
     server._setup_tools()
     return server


### PR DESCRIPTION
## Summary
- release  0.2.3
- add safe hot-reload support for 
- keep reload markers aligned with the exact config snapshot that was loaded
- add regression coverage for invalid live edits and changes during reload

## Verification
- uv run python -m pytest tests/test_connections_reload.py tests/test_run_query_file_output.py tests/test_connector_implementations.py tests/test_server.py tests/test_mcp_server.py
- uv run python -m pytest tests/test_server.py tests/test_cli_versions.py -q -k 'package_version_matches_distribution_metadata or support_version'
- uv build