### PR TITLE
Release 0.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project aims to follow [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+## [0.3.0] - 2026-06-08
+
 ### Added
 
 - SSH tunnels accept configurations without `private_key` or `password`. When

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "mcp-read-only-sql"
-version = "0.2.6"
+version = "0.3.0"
 description = "MCP server for read-only SQL queries supporting PostgreSQL and ClickHouse"
 readme = "README.md"
 requires-python = ">=3.11"


### PR DESCRIPTION
Cuts the 0.3.0 release per RELEASING.md.

Releases the SSH ssh-agent / OpenSSH-config fallback work from #20.

- Move the Unreleased entries (SSH ssh-agent/OpenSSH-config fallback, CLI tunnel 30s default + readiness poll) into a new `## [0.3.0] - 2026-06-08` section in CHANGELOG.md.
- Bump `[project].version` 0.2.6 → 0.3.0 in pyproject.toml.

Minor bump (SemVer): new user-facing SSH-auth capability plus a changed CLI tunnel startup default.

After merge, tag the release commit and push the tag to trigger publish.yml:

    git tag v0.3.0 && git push origin v0.3.0

then approve the `pypi` environment deployment.